### PR TITLE
Allow passing  args to mongod

### DIFF
--- a/3.6/rootfs/run.sh
+++ b/3.6/rootfs/run.sh
@@ -11,4 +11,4 @@ ARGS="--config /opt/bitnami/mongodb/conf/mongodb.conf"
 sed -i 's/path: .*\/mongodb.log/path: /' /bitnami/mongodb/conf/mongodb.conf
 
 info "Starting ${DAEMON}..."
-exec gosu ${USER} ${EXEC} ${ARGS}
+exec gosu ${USER} ${EXEC} ${ARGS} "$@"

--- a/3.7/rootfs/run.sh
+++ b/3.7/rootfs/run.sh
@@ -11,4 +11,4 @@ ARGS="--config /opt/bitnami/mongodb/conf/mongodb.conf"
 sed -i 's/path: .*\/mongodb.log/path: /' /bitnami/mongodb/conf/mongodb.conf
 
 info "Starting ${DAEMON}..."
-exec gosu ${USER} ${EXEC} ${ARGS}
+exec gosu ${USER} ${EXEC} ${ARGS} "$@"


### PR DESCRIPTION
Sometime it is required to pass extra args to mongod, this
changes allow running mongodb container as following:

```
docker run bitnami/mongodb /run.sh --arg1 --arg2
```