### PR TITLE
Fix check NULL of shell

### DIFF
--- a/3.6/debian-9/rootfs/run.sh
+++ b/3.6/debian-9/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"

--- a/3.6/ol-7/rootfs/run.sh
+++ b/3.6/ol-7/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"

--- a/4.0/debian-9/rootfs/run.sh
+++ b/4.0/debian-9/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"

--- a/4.0/ol-7/rootfs/run.sh
+++ b/4.0/ol-7/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"

--- a/4.1/debian-9/rootfs/run.sh
+++ b/4.1/debian-9/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"

--- a/4.1/ol-7/rootfs/run.sh
+++ b/4.1/ol-7/rootfs/run.sh
@@ -25,7 +25,7 @@ fi
 sed -i 's/path: .*\/mongodb.log/path: /' /opt/bitnami/mongodb/conf/mongodb.conf
 
 # allow running custom initialization scripts
-if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then
+if [[ "$(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)")" != "" ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]]; then
     mongodbStart &
     pidfile="/opt/bitnami/mongodb/tmp/mongodb.pid"
     dbpath="/bitnami/mongodb/data/db"


### PR DESCRIPTION
The '-n' just check NULL, but the 'find' does not return NULL.

My test case:
```
$ kubectl exec -it    kubeapps-mongodb-6c76498b98-jlq69  -n kube-system   sh

sh-4.2$ if [[ ! $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then  echo "test"; fi
test

sh-4.2$ if [[ -n $(find /docker-entrypoint-initdb.d/ -type f -regex ".*\.\(sh\|js\)") ]] && [[ ! -f /bitnami/mongodb/.user_scripts_initialized ]] ; then  echo "test"; fi
sh-4.2$ 
```

It lost my times...