### PR TITLE
Changed from appending key to keyfile to re-wrting keyfile on contain…

### DIFF
--- a/3.6/debian-9/rootfs/libmongodb.sh
+++ b/3.6/debian-9/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 

--- a/3.6/ol-7/rootfs/libmongodb.sh
+++ b/3.6/ol-7/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 

--- a/4.0/debian-9/rootfs/libmongodb.sh
+++ b/4.0/debian-9/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 

--- a/4.0/ol-7/rootfs/libmongodb.sh
+++ b/4.0/ol-7/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 

--- a/4.1/debian-9/rootfs/libmongodb.sh
+++ b/4.1/debian-9/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 

--- a/4.1/ol-7/rootfs/libmongodb.sh
+++ b/4.1/ol-7/rootfs/libmongodb.sh
@@ -445,7 +445,7 @@ mongodb_configure_key_file() {
     local key="${2:?key is required}"
 
     info "Writing keyfile for replica set authentication: $key $keyfile"
-    echo "$key" >> "$keyfile"
+    echo "$key" > "$keyfile"
 
     chmod 600 "$keyfile"
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Changed from appending the supplied to an existing key file to re-writing the key on each container start.

**Benefits**

Ensures cluster keys are always in sync and inter-node authentication and communication is possible

**Possible drawbacks**

None that I am aware of

**Applicable issues**

https://github.com/bitnami/bitnami-docker-mongodb/issues/159
