### PR TITLE
fix error exit message when `MONGODB_PASSWORD` is not specified with `MONGODB_USERNAME`

### DIFF
--- a/3.6/debian-9/rootfs/libmongodb.sh
+++ b/3.6/debian-9/rootfs/libmongodb.sh
@@ -133,7 +133,7 @@ Available options are 'primary/secondary/arbiter'"
         warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
     elif [[ -n "$MONGODB_USERNAME" ]] && [[ -z "$MONGODB_PASSWORD" ]]; then
         error_message="The MONGODB_PASSWORD environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
-        print_error_exit
+        print_error_exit "$error_message"
     fi
 }
 

--- a/4.0/debian-9/rootfs/libmongodb.sh
+++ b/4.0/debian-9/rootfs/libmongodb.sh
@@ -133,7 +133,7 @@ Available options are 'primary/secondary/arbiter'"
         warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
     elif [[ -n "$MONGODB_USERNAME" ]] && [[ -z "$MONGODB_PASSWORD" ]]; then
         error_message="The MONGODB_PASSWORD environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
-        print_error_exit
+        print_error_exit "$error_message"
     fi
 }
 

--- a/4.1/debian-9/rootfs/libmongodb.sh
+++ b/4.1/debian-9/rootfs/libmongodb.sh
@@ -133,7 +133,7 @@ Available options are 'primary/secondary/arbiter'"
         warn "You set the environment variable ALLOW_EMPTY_PASSWORD=${ALLOW_EMPTY_PASSWORD}. For safety reasons, do not use this flag in a production environment."
     elif [[ -n "$MONGODB_USERNAME" ]] && [[ -z "$MONGODB_PASSWORD" ]]; then
         error_message="The MONGODB_PASSWORD environment variable is empty or not set. Set the environment variable ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords. This is recommended only for development."
-        print_error_exit
+        print_error_exit "$error_message"
     fi
 }
 


### PR DESCRIPTION
**Description of the change**

Correctly prints the error exit message when `MONGODB_PASSWORD` is not specified for `MONGODB_USERNAME`

**Benefits**

Prints the correct error message so that user is aware why the container creation is failing.

**Possible drawbacks**

None

**Applicable issues**

None