### PR TITLE
Allow to provide replica set member config

### DIFF
--- a/4.2/debian-9/rootfs/libmongodb.sh
+++ b/4.2/debian-9/rootfs/libmongodb.sh
@@ -602,7 +602,10 @@ mongodb_is_secondary_node_pending() {
     local result
 
     result=$(mongodb_execute "$MONGODB_PRIMARY_ROOT_USER" "$MONGODB_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_PRIMARY_HOST" "$MONGODB_PRIMARY_PORT_NUMBER" <<EOF
-rs.add('$node:$MONGODB_PORT_NUMBER')
+rs.add({
+    host: '$node:$MONGODB_PORT_NUMBER',
+    $MONGODB_MEMBER_CONFIG
+})
 EOF
 )
     grep -q "\"ok\" : 1" <<< "$result"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->

This PR introduces the `MONGODB_MEMBER_CONFIG` env variable that allows to configure replica set members.

Note that I only did the change for the 4.2/debian `libmongo.sh` script to know whether you'd be interested in such a change. Also documentation is missing. I can add the missing pieces once there is a general agreement on this change.

Currently this change allows to set the config only on the initial setup. Support for patching the config could be added by executing the following snippet on the primary node in `mongodb_configure_secondary` when `mongodb_node_currently_in_cluster "$node"` is true:
```js
var config = rs.config();
config.members.find((member) => {
  if(member.host === '$node') {
    var newConfig = {$MONGODB_MEMBER_CONFIG};
    Object.keys(newConfig).forEach((key) => {
      member[key] = newConfig[key];
    });
  }
});
rs.reconfig(config);
```
What do you think about this?

**Benefits**

<!-- What benefits will be realized by the code change? -->

This change allows to deploy hidden members into a replica set by passing `MONGODB_MEMBER_CONFIG=hidden: true, priority: 0` as an env var.

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
