### PR TITLE
Allow Secondary to Rejoin Cluster

### DIFF
--- a/3.6/debian-9/rootfs/libmongodb.sh
+++ b/3.6/debian-9/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/3.6/debian-9/rootfs/libmongodb.sh
+++ b/3.6/debian-9/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################

--- a/3.6/ol-7/rootfs/libmongodb.sh
+++ b/3.6/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/3.6/ol-7/rootfs/libmongodb.sh
+++ b/3.6/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################

--- a/4.0/debian-9/rootfs/libmongodb.sh
+++ b/4.0/debian-9/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/4.0/debian-9/rootfs/libmongodb.sh
+++ b/4.0/debian-9/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################

--- a/4.0/ol-7/rootfs/libmongodb.sh
+++ b/4.0/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/4.0/ol-7/rootfs/libmongodb.sh
+++ b/4.0/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################

--- a/4.2/debian-10/rootfs/libmongodb.sh
+++ b/4.2/debian-10/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/4.2/debian-10/rootfs/libmongodb.sh
+++ b/4.2/debian-10/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################

--- a/4.2/ol-7/rootfs/libmongodb.sh
+++ b/4.2/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,7 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1" <<< "$result"
+    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
 }
 
 ########################

--- a/4.2/ol-7/rootfs/libmongodb.sh
+++ b/4.2/ol-7/rootfs/libmongodb.sh
@@ -605,7 +605,15 @@ mongodb_is_secondary_node_pending() {
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
-    grep -q "\"ok\" : 1\|\"code\" : 103" <<< "$result"
+    # Error code 103 is considered OK.
+    # It indicates a possiblely desynced configuration,
+    # which will become resynced when the secondary joins the replicaset.
+    if grep -q "\"code\" : 103" <<< "$result"; then
+      warn "The ReplicaSet configuration is not aligned with primary node's configuration. Starting secondary node so it syncs with ReplicaSet..."
+      return 0
+    fi
+
+    grep -q "\"ok\" : 1" <<< "$result"
 }
 
 ########################


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Fixes issue (#198) where occasionally a secondary replica enters a permanent state of being unable to join the replicaset due to misconfiguration.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

<!-- What benefits will be realized by the code change? -->

Enabled secondary replica to survive a restart

**Possible drawbacks**

<!-- Describe any known limitations with your change -->

Unknown

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

It's essential that nodes don't enter permanent dead states in production
