### PR TITLE
replicaset connection for primary node discovery

### DIFF
--- a/4.4/debian-10/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/4.4/debian-10/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -590,7 +590,9 @@ mongodb_is_secondary_node_pending() {
     local node="${1:?node is required}"
     local result
 
-    result=$(mongodb_execute "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
+    local repl_set_host="${MONGODB_REPLICA_SET_NAME}/${MONGODB_INITIAL_PRIMARY_HOST}"
+
+    result=$(mongodb_execute "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$repl_set_host" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
 rs.add('$node:$MONGODB_PORT_NUMBER')
 EOF
 )
@@ -659,7 +661,9 @@ mongodb_configure_primary() {
 mongodb_is_node_confirmed() {
     local -r node="${1:?node is required}"
 
-    result=$(mongodb_execute "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$MONGODB_INITIAL_PRIMARY_HOST" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
+    local repl_set_host="${MONGODB_REPLICA_SET_NAME}/${MONGODB_INITIAL_PRIMARY_HOST}"
+
+    result=$(mongodb_execute "$MONGODB_INITIAL_PRIMARY_ROOT_USER" "$MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD" "admin" "$repl_set_host" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
 rs.status().members
 EOF
 )
@@ -702,7 +706,9 @@ mongodb_is_primary_node_up() {
 
     debug "Validating $host as primary node..."
 
-    result=$(mongodb_execute "$user" "$password" "admin" "$host" "$port" <<EOF
+    local repl_set_host="${MONGODB_REPLICA_SET_NAME}/${MONGODB_INITIAL_PRIMARY_HOST}"
+
+    result=$(mongodb_execute "$user" "$password" "admin" "$repl_set_host" "$port" <<EOF
 db.isMaster().ismaster
 EOF
 )
@@ -724,8 +730,10 @@ mongodb_is_node_available() {
     local -r user="${3:?user is required}"
     local -r password="${4:-}"
 
+    local repl_set_host="${MONGODB_REPLICA_SET_NAME}/${MONGODB_INITIAL_PRIMARY_HOST}"
+
     local result
-    result=$(mongodb_execute "$user" "$password" "admin" "$host" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
+    result=$(mongodb_execute "$user" "$password" "admin" "$repl_set_host" "$MONGODB_INITIAL_PRIMARY_PORT_NUMBER" <<EOF
 db.getUsers()
 EOF
 )


### PR DESCRIPTION
**Description of the change**

<!-- Describe the scope of your change - i.e. what the change does. -->
It prepends the replicaset name from `MONGODB_REPLICA_SET_NAME` environment variable to the host provided by `MONGODB_INITIAL_PRIMARY_HOST` when mongo shell is instantiated on configuration scripts, allowing primary node discovery.

**Benefits**

<!-- What benefits will be realized by the code change? -->
In case the primary node has changed from the one provided by `MONGODB_INITIAL_PRIMARY_HOST`, mongo shell instances will be able to discover the primary node. Motivation is described on referenced issue.

**Possible drawbacks**

This approach doesn't handle the case when the replicaset will be scaled up but the host provided by `MONGODB_INITIAL_PRIMARY_HOST` is not available (maybe on a k8s environment we could use headless service to discover all other nodes).

**Applicable issues**

Original issue was reported at bitnami/mongodb helm chart.
https://github.com/bitnami/charts/issues/3877 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->
Tested by modifying 4.4 image and deploying it to a k8s cluster through helm chart. Then primary node was changed using steps mentioned in the issue. Proceeded to scale up the cluster. As a result, new nodes were able to discover the primary node and were successfully added into the replicaset.