### PR TITLE
fixed docker-compose.yml example

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "27017:27017"
     volumes:
-      - 'mongodb_data:/bitnami/mongodb'
+      - './mongodb_data:/bitnami/mongodb'
 
 volumes:
   mongodb_data:


### PR DESCRIPTION
When running docker-compose up, no directory (at least not on all systems) is created as mentioned in the docker-compose.yml ('mongodb_data:/bitnami/mongodb'). Usually in my experience it's better to work with the dot ./<relative-file-path> when using relative paths. Therefore it should be ./mongodb_data:/bitnami/mongodb

My OS / Docker Setup: 
OS: Ubuntu 20.04
Docker: Docker version 20.10.5, build 55c4c88