### PR TITLE
Attempt fix of Issue #259 due : change the variable tested for extra args

### DIFF
--- a/4.4/debian-10/rootfs/opt/bitnami/scripts/libmongodb.sh
+++ b/4.4/debian-10/rootfs/opt/bitnami/scripts/libmongodb.sh
@@ -142,7 +142,7 @@ mongodb_execute() {
     if [[ -n "$extra_args" ]]; then
         local extra_args_array=()
         read -r -a extra_args_array <<< "$extra_args"
-        [[ "${#extra_args[@]}" -gt 0 ]] && args+=("${extra_args_array[@]}")
+        [[ "${#extra_args_array[@]}" -gt 0 ]] && args+=("${extra_args_array[@]}")
     fi
     [[ -n "$database" ]] && args+=("$database")
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Change the size test done within mongodb_execute function to check extra_args that might have been passed in via a parameter or default of $MONGODB_CLIENT_EXTRA_FLAGS. An error was occurring in some instances when $extra_args was a string; instead change to use $extra_args_array as this will be an array/list due to the read -a done when initialising.

**Benefits**

Prevent an error occurring when there was a type mis-match

**Possible drawbacks**

None known - though further testing beneficial with different configuration.

**Applicable issues**

bitnami#259

**Additional information**

